### PR TITLE
Optimizing Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # TODO: FPR: Consider an alpine image
 # TODO: FPR: Add label describing intent of this image
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 # Required to avoid interaction while doing apt udpate
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Fixes #2 
Changing to `Alpine` will not work since many of the required packages are not available on that. However, I've changed the base image to one of Ubuntu's minimal images which is much lighter.